### PR TITLE
bump domify to 1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "carry": "0.0.2",
     "component-classes": "1.2.2",
     "debug": "0.7.4",
-    "domify": "1.2.1",
+    "domify": "1.3.2",
     "emitter-component": "1.1.1",
     "event-component": "0.1.0",
     "query-component": "0.0.1"


### PR DESCRIPTION
Adds support for `<g>` tags. See: https://github.com/component/domify/commit/313c80fa54469115352398b156d2764a0a3b0f74

Tests pass locally.